### PR TITLE
Deployed version save file edit

### DIFF
--- a/Division Tracking/divisionTracker.m
+++ b/Division Tracking/divisionTracker.m
@@ -855,7 +855,11 @@ if divisionSettings.detected == 1
         end
     end
     
-    save([root,filesep,'Tracks.mat'],'divisionSettings','toMappings','fromMappings','procTracks','-append')
+    if isdeployed
+        save([root,filesep,'Tracks.mat'],'divisionSettings','toMappings','fromMappings','procTracks','-append','-v6')
+    else
+        save([root,filesep,'Tracks.mat'],'divisionSettings','toMappings','fromMappings','procTracks','-append','-v7.3')
+    end
     
     debugprogressbar(1,debugSet)
 end

--- a/Feature Extraction/extractFeatureEngine.m
+++ b/Feature Extraction/extractFeatureEngine.m
@@ -286,7 +286,11 @@ if customise
     end
 end
 
-save(cellFeaturesPath,'-v7.3','maxT','trackableData','featSettings')
+if isdeployed
+    save(cellFeaturesPath,'maxT','trackableData','featSettings','-v6')
+else
+    save(cellFeaturesPath,'maxT','trackableData','featSettings','-v7.3')
+end
 
 %If there is only one timepoint available, still want to make data
 %available for plotting and overlays. Convert to 'Tracks.mat' format for
@@ -344,7 +348,11 @@ if size(trackableData.(featNames{1}),1) == 1
     
     fromMappings = [];
     
-    save([root,filesep,'Tracks.mat'],'-v7.3','procTracks','trackSettings','toMappings','fromMappings')
+    if isdeployed
+        save([root,filesep,'Tracks.mat'],'procTracks','trackSettings','toMappings','fromMappings','-v6')
+    else
+        save([root,filesep,'Tracks.mat'],'procTracks','trackSettings','toMappings','fromMappings','-v7.3')
+    end
 end
 
 debugprogressbar(1,debugSet)

--- a/Plotting/plotTracks.m
+++ b/Plotting/plotTracks.m
@@ -712,7 +712,11 @@ global plotExport
 global plotSettings
 global root
 
-save([root,filesep,'plotDataExport.mat'],'plotExport','plotSettings')
+if isdeployed
+    save([root,filesep,'plotDataExport.mat'],'plotExport','plotSettings','-v6')
+else
+    save([root,filesep,'plotDataExport.mat'],'plotExport','plotSettings','-v7.3')
+end
 
 % --------------------------------------------------------------------
 function save_fig_Callback(hObject, eventdata, handles)

--- a/Tracking/TrackCorrection/CorrectTracks.m
+++ b/Tracking/TrackCorrection/CorrectTracks.m
@@ -476,9 +476,16 @@ global debugSet
 
 debugprogressbar(0,debugSet)
 
-save([GUIsets.root,filesep,'Tracks.mat'],'rawFromMappings','rawToMappings','rawTracks','trackTimes','-append');
-if exist(fullfile(GUIsets.root,'Pre-division_Tracks.mat'),'file')
-    save(fullfile(GUIsets.root,'Pre-division_Tracks.mat'),'rawFromMappings','rawToMappings','rawTracks','trackTimes','-append');
+if isdeployed
+    save([GUIsets.root,filesep,'Tracks.mat'],'rawFromMappings','rawToMappings','rawTracks','trackTimes','-append','-v6');
+    if exist(fullfile(GUIsets.root,'Pre-division_Tracks.mat'),'file')
+        save(fullfile(GUIsets.root,'Pre-division_Tracks.mat'),'rawFromMappings','rawToMappings','rawTracks','trackTimes','-append','-v6');
+    end
+else
+    save([GUIsets.root,filesep,'Tracks.mat'],'rawFromMappings','rawToMappings','rawTracks','trackTimes','-append','-v7.3');
+    if exist(fullfile(GUIsets.root,'Pre-division_Tracks.mat'),'file')
+        save(fullfile(GUIsets.root,'Pre-division_Tracks.mat'),'rawFromMappings','rawToMappings','rawTracks','trackTimes','-append','-v7.3');
+    end
 end
 
 debugprogressbar(1,debugSet)

--- a/Tracking/diffusionTracker.m
+++ b/Tracking/diffusionTracker.m
@@ -472,7 +472,11 @@ plotTrackLengthDistribution(rawTracks.(trackDataNames{1}),handles.axes3,trackSet
 trackSettings.tracked = 1;
 handles.ValidateButt.Enable = 'on';
 
-save([root,filesep,'Tracks.mat'],'procTracks','rawFromMappings','rawToMappings','rawTracks','trackTimes','toMappings','fromMappings','trackSettings','trackableData','linkStats','-v7.3')
+if isdeployed
+    save([root,filesep,'Tracks.mat'],'procTracks','rawFromMappings','rawToMappings','rawTracks','trackTimes','toMappings','fromMappings','trackSettings','trackableData','linkStats','-v6')
+else
+    save([root,filesep,'Tracks.mat'],'procTracks','rawFromMappings','rawToMappings','rawTracks','trackTimes','toMappings','fromMappings','trackSettings','trackableData','linkStats','-v7.3')
+end
 
 debugprogressbar([1;1;1],debugSet);
 
@@ -1119,7 +1123,11 @@ if trackSettings.tracked
     
     %Do the track data processing in the background (once the track lengths have been plotted)
     [procTracks,fromMappings,toMappings] = processTracks(rawTracks,rawFromMappings,rawToMappings,trackSettings,trackTimes,debugSet);
-    save([root,filesep,'Tracks.mat'],'procTracks','fromMappings','toMappings','-v7.3','-append')
+    if isdeployed
+        save([root,filesep,'Tracks.mat'],'procTracks','fromMappings','toMappings','-v6','-append')
+    else
+        save([root,filesep,'Tracks.mat'],'procTracks','fromMappings','toMappings','-v7.3','-append')
+    end
 
     debugprogressbar([1;1;1],debugSet)
 end
@@ -1172,7 +1180,12 @@ if trackSettings.tracked
     
     %Do the track data processing in the background (once the track lengths have been plotted)
     [procTracks,fromMappings,toMappings] = processTracks(rawTracks,rawFromMappings,rawToMappings,trackSettings,trackTimes,debugSet);
-    save([root,filesep,'Tracks.mat'],'procTracks','fromMappings','toMappings','-append')
+    
+    if isdeployed
+        save([root,filesep,'Tracks.mat'],'procTracks','fromMappings','toMappings','-append','-v6')
+    else
+        save([root,filesep,'Tracks.mat'],'procTracks','fromMappings','toMappings','-append','-v7.3')
+    end
 
     debugprogressbar([1;1;1],debugSet)
 end

--- a/homePanel/importBioformatsData.m
+++ b/homePanel/importBioformatsData.m
@@ -153,4 +153,9 @@ end
 debugprogressbar([1;1],debugSet) %Make sure the modal loading bar has definitely closed
 
 metaName = [rootdir,filesep,'Metadata.mat'];
-save(metaName,'metaStore')
+
+if isdeployed
+    save(metaName,'metaStore','-v6')
+else
+    save(metaName,'metaStore','-v7.3')
+end


### PR DESCRIPTION
Adds additional isdeployed checks to several save statements, allowing easy switching between v6 and v7.3 .mat files between deployed and Matlab-native versions of FAST, respectively.